### PR TITLE
Fixed 2 statuscodes.

### DIFF
--- a/src/login/controller.ts
+++ b/src/login/controller.ts
@@ -60,7 +60,7 @@ class LoginController extends Controller {
 
   async redirectToLogin(ctx: Context, msg: string) {
 
-    ctx.response.status = 302;
+    ctx.response.status = 303;
     ctx.response.headers.set('Location', '/login?' + querystring.stringify({ msg }));
 
   }

--- a/src/register/controller.ts
+++ b/src/register/controller.ts
@@ -43,8 +43,7 @@ class RegistrationController extends Controller {
 
     await userService.createPassword(user, userPassword);
 
-
-    ctx.status = 308;
+    ctx.status = 303;
     ctx.response.headers.set('Location', '/login?msg=Registration+successful.+Please log in');
 
   }


### PR DESCRIPTION
The '308' code in particular was bad, because it causes a browser to
re-submit the POST request to /login. This caused the problem where a
user would get 'incorrect username & password' after registering.