### PR TITLE
Fix optional OAuth2 TOTP.

### DIFF
--- a/src/login/controller.ts
+++ b/src/login/controller.ts
@@ -5,7 +5,7 @@ import querystring from 'querystring';
 import log from '../log/service';
 import { EventType } from '../log/types';
 import { getSetting } from '../server-settings';
-import * as UserService from '../user/service';
+import * as userService from '../user/service';
 import { User } from '../user/types';
 import { loginForm } from './formats/html';
 
@@ -25,7 +25,7 @@ class LoginController extends Controller {
 
     let user: User;
     try {
-      user = await UserService.findByIdentity('mailto:' + ctx.request.body.userName);
+      user = await userService.findByIdentity('mailto:' + ctx.request.body.userName);
     } catch (err) {
       if (err instanceof NotFound) {
         log(EventType.loginFailed, ctx);
@@ -35,17 +35,17 @@ class LoginController extends Controller {
       }
     }
 
-    if (!await UserService.validatePassword(user, ctx.request.body.password)) {
+    if (!await userService.validatePassword(user, ctx.request.body.password)) {
       log(EventType.loginFailed, ctx.ip(), user.id);
       return this.redirectToLogin(ctx, 'Incorrect username or password');
     }
 
     if (ctx.request.body.totp) {
-        if (!await UserService.validateTotp(user, ctx.request.body.totp)) {
+        if (!await userService.validateTotp(user, ctx.request.body.totp)) {
           log(EventType.totpFailed, ctx.ip(), user.id);
           return this.redirectToLogin(ctx, 'Incorrect TOTP code');
         }
-    } else if (await UserService.hasTotp(user)) {
+    } else if (await userService.hasTotp(user)) {
         return this.redirectToLogin(ctx, 'TOTP token required');
     }
 

--- a/src/oauth2/controller/authorize.ts
+++ b/src/oauth2/controller/authorize.ts
@@ -135,9 +135,13 @@ class AuthorizeController extends Controller {
       return this.redirectToLogin(ctx, { ...params, msg: 'Incorrect username or password'});
     }
 
-    if (!await userService.validateTotp(user, ctx.request.body.totp)) {
-      log(EventType.totpFailed, ctx.ip(), user.id);
-      return this.redirectToLogin(ctx, { ...params, msg: 'Incorrect TOTP code'});
+    if (ctx.request.body.totp) {
+      if (!await userService.validateTotp(user, ctx.request.body.totp)) {
+          log(EventType.totpFailed, ctx.ip(), user.id);
+        return this.redirectToLogin(ctx, {...params, msg: 'Incorrect TOTP code'});
+        }
+    } else if (await userService.hasTotp(user)) {
+      return this.redirectToLogin(ctx, {...params, msg: 'TOTP token required'});
     }
 
     ctx.state.session = {

--- a/src/oauth2/controller/authorize.ts
+++ b/src/oauth2/controller/authorize.ts
@@ -138,7 +138,7 @@ class AuthorizeController extends Controller {
     if (ctx.request.body.totp) {
       if (!await userService.validateTotp(user, ctx.request.body.totp)) {
           log(EventType.totpFailed, ctx.ip(), user.id);
-        return this.redirectToLogin(ctx, {...params, msg: 'Incorrect TOTP code'});
+          return this.redirectToLogin(ctx, {...params, msg: 'Incorrect TOTP code'});
         }
     } else if (await userService.hasTotp(user)) {
       return this.redirectToLogin(ctx, {...params, msg: 'TOTP token required'});


### PR DESCRIPTION
TOTP codes were made optional a while back. This was fixed for the
/login endpoint, but not for the /authorize endpoint (which is used by
OAuth2).